### PR TITLE
fix: Correct auto-merge workflow trigger syntax

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -30,20 +30,27 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const pr = context.payload.pull_request;
+            // Handle different trigger contexts
+            let prNumber;
             
-            if (!pr) {
+            if (context.payload.pull_request) {
+              // Triggered by pull_request or check_suite
+              prNumber = context.payload.pull_request.number;
+            } else if (context.payload.workflow_run?.pull_requests?.length > 0) {
+              // Triggered by workflow_run
+              prNumber = context.payload.workflow_run.pull_requests[0].number;
+            } else {
               console.log('No PR found in context');
               return;
             }
             
-            console.log(`Checking PR #${pr.number}...`);
+            console.log(`Checking PR #${prNumber}...`);
             
             // Get PR details
             const { data: pullRequest } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: pr.number,
+              pull_number: prNumber,
             });
             
             // Check if PR is already merged or closed


### PR DESCRIPTION
Fixes the auto-merge workflow YAML syntax error.

## Changes
- Replace invalid `status: {}` trigger with `workflow_run` trigger
- This properly waits for CI workflow completion before attempting auto-merge

## Testing
This PR will test the auto-merge functionality. If all checks pass, it should automatically squash merge itself! 🚀

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch auto-merge to trigger on completed CI runs and update script to resolve PR number from pull_request or workflow_run contexts.
> 
> - **GitHub Actions (auto-merge workflow)**
>   - **Triggers**: Replace invalid `status: {}` with `workflow_run` for `"CI"` on `completed` events; keep existing `pull_request` and `check_suite` triggers.
>   - **Script**:
>     - Determine `prNumber` from `pull_request` or `workflow_run.pull_requests[0]`.
>     - Update logging and API calls to use `prNumber`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34c77e66e0c5651c3ecc1a071b6fc696e6f4c2ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->