### PR TITLE
feat: Wait for all checks including Cursor Bugbot before auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -84,9 +84,22 @@ jobs:
               statuses.statuses.every(status => status.state === 'success');
             
             // Check if all check runs passed (excluding this workflow)
+            // Wait for ALL checks to complete, including optional ones like Cursor Bugbot
             const allChecksPassed = checkRuns.check_runs
               .filter(check => check.name !== 'Auto Merge PR')
-              .every(check => check.status === 'completed' && check.conclusion === 'success');
+              .every(check =>
+                check.status === 'completed' &&
+                (check.conclusion === 'success' || check.conclusion === 'skipped')
+              );
+
+            // Check if any checks are still pending
+            const pendingChecks = checkRuns.check_runs
+              .filter(check => check.name !== 'Auto Merge PR' && check.status !== 'completed')
+              .map(check => check.name);
+
+            if (pendingChecks.length > 0) {
+              console.log(`Waiting for checks to complete: ${pendingChecks.join(', ')}`);
+            }
             
             console.log(`All statuses passed: ${allStatusesPassed}`);
             console.log(`All checks passed: ${allChecksPassed}`);


### PR DESCRIPTION
Enhanced auto-merge workflow to wait for all checks including optional ones like Cursor Bugbot.\n\n## Changes\n- ✅ Wait for ALL checks to complete (not just required ones)\n- ✅ Accept 'skipped' conclusions as valid\n- ✅ Log pending checks for better debugging\n- ✅ More comprehensive logging for troubleshooting\n\n## Testing\nThis PR will test the enhanced auto-merge workflow. If all checks pass (including Cursor Bugbot), it should automatically merge itself! 🚀

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates auto-merge to wait for all check runs to complete, treat skipped as pass, and log pending checks.
> 
> - **CI / Auto-merge (`.github/workflows/auto-merge.yml`)**:
>   - Wait for all check runs to complete (including optional ones).
>   - Treat `skipped` conclusions as passing alongside `success`.
>   - Log names of pending checks while waiting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6b31b5949a3d4157b94b8e402980cbc86504d2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->