### PR TITLE
fix: Remove invalid Turbo env vars and fix markdown linting error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,9 +147,6 @@ jobs:
 
       - name: Build all packages
         run: bun run build
-        env:
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN || '' }}
-          TURBO_TEAM: ${{ secrets.TURBO_TEAM || '' }}
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -217,7 +217,7 @@ When you run `bun run dev`, the **OpenAPI documentation** automatically opens in
 
 **Manual Access:**
 
-```
+```text
 http://localhost:3000/api/docs
 ```
 


### PR DESCRIPTION
- Remove TURBO_TOKEN and TURBO_TEAM from CI workflow (causing context access errors)
- Add 'text' language specifier to fenced code block in API README (fixes MD040)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `TURBO_TOKEN`/`TURBO_TEAM` from CI build step and specifies `text` language for a code block in the API README.
> 
> - **CI**:
>   - Remove `TURBO_TOKEN` and `TURBO_TEAM` env vars from the `Build all packages` step in `.github/workflows/ci.yml`.
> - **Docs**:
>   - Set code fence language to `text` for the "Manual Access" URL block in `apps/api/README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d5d0d0dfc3fc23bf4c6cc0c637216c2e825d7e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->